### PR TITLE
Only flash "needs_refresh_message" if value is set

### DIFF
--- a/flask_login/login_manager.py
+++ b/flask_login/login_manager.py
@@ -270,12 +270,13 @@ class LoginManager(object):
         if not self.refresh_view:
             abort(401)
 
-        if self.localize_callback is not None:
-            flash(self.localize_callback(self.needs_refresh_message),
-                  category=self.needs_refresh_message_category)
-        else:
-            flash(self.needs_refresh_message,
-                  category=self.needs_refresh_message_category)
+        if self.needs_refresh_message:
+            if self.localize_callback is not None:
+                flash(self.localize_callback(self.needs_refresh_message),
+                      category=self.needs_refresh_message_category)
+            else:
+                flash(self.needs_refresh_message,
+                      category=self.needs_refresh_message_category)
 
         config = current_app.config
         if config.get('USE_SESSION_FOR_NEXT', USE_SESSION_FOR_NEXT):


### PR DESCRIPTION
This is already the beahaviour for "login_message".
This PR adds the same behaviour for "needs_refresh_message" (which you can't disable at the moment)